### PR TITLE
Fix CL-SEC-2026-0160: replace read-from-string with parse-integer for port parsing

### DIFF
--- a/src.lisp
+++ b/src.lisp
@@ -454,8 +454,7 @@
 
     (when host (setq host (decode-escaped-encoding host escape)))
     (when port
-      (setq port (read-from-string port))
-      (when (not (numberp port)) (error "port is not a number: ~s." port))
+      (setq port (parse-integer port :junk-allowed nil))
       (when (not (plusp port))
         (error "port is not a positive integer: ~d." port))
       (when (eql port (case scheme


### PR DESCRIPTION
## Summary

- **CL-SEC-2026-0160** (CVSS 10.0 Critical): `parse-uri` uses `read-from-string` to parse the port component of a URI. The Common Lisp reader executes arbitrary code via `#.` reader macros when `*read-eval*` is T (the default). Any application that parses a user-supplied URL is vulnerable to remote code execution.
- Replace `read-from-string` with `parse-integer`, which only parses decimal integers and has no code execution risk.
- The separate `numberp` check is removed since `parse-integer` signals a `parse-error` on non-numeric input.

## Reproduction

```lisp
;; This executes (+ 1 2) at read time — demonstrates arbitrary code execution
(puri:parse-uri "http://example.com:#.(+ 1 2)/path")
```

## Test plan

- [ ] Verify standard URIs still parse correctly: `http://example.com:8080/path`
- [ ] Verify non-numeric ports signal an error: `http://example.com:abc/path`
- [ ] Verify `#.` reader macros no longer execute: `http://example.com:#.(+ 1 2)/path`
- [ ] Verify default port elision still works: `http://example.com:80/` → port nil

🤖 Generated with [Claude Code](https://claude.com/claude-code)